### PR TITLE
Switch from ? to * in docs and examples

### DIFF
--- a/src/test/resources/moo.scala
+++ b/src/test/resources/moo.scala
@@ -1,4 +1,4 @@
 object Moo {
   def test[F[_]](): Unit = {}
-  t@test@est[E@either@ither[Thr@throwable@owable, ?]]()
+  t@test@est[E@either@ither[Thr@throwable@owable, *]]()
 }

--- a/src/test/scala/functor.scala
+++ b/src/test/scala/functor.scala
@@ -4,7 +4,7 @@ trait Functor[M[_]] {
   def fmap[A, B](fa: M[A])(f: A => B): M[B]
 }
 
-class EitherRightFunctor[L] extends Functor[Either[L, ?]] {
+class EitherRightFunctor[L] extends Functor[Either[L, *]] {
   def fmap[A, B](fa: Either[L, A])(f: A => B): Either[L, B] =
     fa match {
       case Right(a) => Right(f(a))

--- a/src/test/scala/issue80.scala
+++ b/src/test/scala/issue80.scala
@@ -9,8 +9,8 @@ trait Bifunctor[F[_[_[_]], _[_[_]]]] {
 final case class Coproduct[A[_[_]], B[_[_]], X[_]](run: Either[A[X], B[X]])
 
 object Coproduct {
-  def coproductBifunctor[X[_]]: Bifunctor[Coproduct[?[_[_]], ?[_[_]], X]] =
-    new Bifunctor[Coproduct[?[_[_]], ?[_[_]], X]] {
+  def coproductBifunctor[X[_]]: Bifunctor[Coproduct[*[_[_]], *[_[_]], X]] =
+    new Bifunctor[Coproduct[*[_[_]], *[_[_]], X]] {
       def bimap[A[_[_]], B[_[_]], C[_[_]], D[_[_]]](abx: Coproduct[A, B, X])(f: A ~~> C, g: B ~~> D): Coproduct[C, D, X] =
         abx.run match {
           case Left(ax)  => Coproduct(Left(f(ax)))

--- a/src/test/scala/nested.scala
+++ b/src/test/scala/nested.scala
@@ -9,5 +9,5 @@ object KindProjectorWarnings {
 
   def f[G[_]]: Unit = ()
 
-  f[Foo[Bar[Int, ?], ?]] // shadowing warning
+  f[Foo[Bar[Int, *], *]] // shadowing warning
 }

--- a/src/test/scala/polylambda.scala
+++ b/src/test/scala/polylambda.scala
@@ -24,9 +24,9 @@ class PolyLambdas {
 
   val kf4 = λ[Option ~>> Option].dingo(_ flatMap (_ => None))
 
-  val kf5 = λ[Map[?, Int] ~> Map[?, Long]](_.map { case (k, v) => (k, v.toLong) }.toMap)
+  val kf5 = λ[Map[*, Int] ~> Map[*, Long]](_.map { case (k, v) => (k, v.toLong) }.toMap)
 
-  val kf6 = λ[ToSelf[Map[?, Int]]](_.map { case (k, v) => (k, v * 2) }.toMap)
+  val kf6 = λ[ToSelf[Map[*, Int]]](_.map { case (k, v) => (k, v * 2) }.toMap)
 
   implicit class FGOps[F[_], A](x: F[A]) {
     def ntMap[G[_]](kf: F ~> G): G[A] = kf(x)
@@ -40,12 +40,12 @@ class PolyLambdas {
   val tupleTakeFirst = λ[λ[A => (A, Int)] ~> List](x => List(x._1))
 
   // All these formulations should be equivalent.
-  def const1[A]                              = λ[ToSelf[Const[A, ?]]](x => x)
-  def const2[A] : ToSelf[Const[A, ?]]        = λ[Const[A, ?] ~> Const[A, ?]](x => x)
-  def const3[A] : Const[A, ?] ~> Const[A, ?] = λ[ToSelf[Const[A, ?]]](x => x)
-  def const4[A]                              = λ[Const[A, ?] ~> Const[A, ?]](x => x)
-  def const5[A] : ToSelf[Const[A, ?]]        = λ[ToSelf[λ[B => Const[A, B]]]](x => x)
-  def const6[A] : Const[A, ?] ~> Const[A, ?] = λ[ToSelf[λ[B => Const[A, B]]]](x => x)
+  def const1[A]                              = λ[ToSelf[Const[A, *]]](x => x)
+  def const2[A] : ToSelf[Const[A, *]]        = λ[Const[A, *] ~> Const[A, *]](x => x)
+  def const3[A] : Const[A, *] ~> Const[A, *] = λ[ToSelf[Const[A, *]]](x => x)
+  def const4[A]                              = λ[Const[A, *] ~> Const[A, *]](x => x)
+  def const5[A] : ToSelf[Const[A, *]]        = λ[ToSelf[λ[B => Const[A, B]]]](x => x)
+  def const6[A] : Const[A, *] ~> Const[A, *] = λ[ToSelf[λ[B => Const[A, B]]]](x => x)
 
   @Test
   def polylambda(): Unit = {

--- a/src/test/scala/tony.scala
+++ b/src/test/scala/tony.scala
@@ -31,8 +31,8 @@ object Main {
   }
   
   // using the plugin, this should be the same (but hopefully easier to read)
-  def KleisliSemigroupoid2[F[_]: FlatMap]: Semigroupoid[Kleisli[?, F, ?]] = {
-    new Semigroupoid[Kleisli[?, F, ?]] {
+  def KleisliSemigroupoid2[F[_]: FlatMap]: Semigroupoid[Kleisli[*, F, *]] = {
+    new Semigroupoid[Kleisli[*, F, *]] {
       def compose[A, B, C] = {
         f => g => Kleisli(a => FlatMap[F].flatMap(g.k)(f.k(a)))
       }


### PR DESCRIPTION
The plan for Dotty is to repurpose `?` for wildcards instead of `_`. In #91 `*` was added to kind-projecter as alternative placeshold syntax to `?`, and Dotty now also supports `*` as placeholder syntax for cross compilation via `-Ykind-projector`.

This PR updates the documentation and examples to use `*` rather than `?` and adds a warning that the `?` syntax will be deprecated in future.