### PR TITLE
Remove line about sonatype from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ To use this plugin in your own projects, add the following lines to
 your `build.sbt` file:
 
 ```scala
-resolvers += Resolver.sonatypeRepo("releases")
-
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
 
 // if your project uses multiple Scala versions, use this for cross building


### PR DESCRIPTION
It seems this project is now hosted on maven, and so we don't need to add sonatype to resolvers.