### PR TITLE
Update README.md - remove double %

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ To use this plugin in your own projects, add the following lines to
 your `build.sbt` file:
 
 ```scala
-addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full)
-
-// if your project uses multiple Scala versions, use this for cross building
 addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.3" cross CrossVersion.full)
 
 // if your project uses both 2.10 and polymorphic lambdas


### PR DESCRIPTION
So... I don't really know why the `%%` variant was there. I've been using the other one (single `%`, `cross CrossVersion.full` included) ever since the switch to this version scheme, including both single-Scala-version and cross-builds, and it's always worked.

Unless there's a reason to have this distinction, I would just leave one definition.