### PR TITLE
Remove deprecated `?` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ avoid defining the following identifiers:
 
  1. `Lambda` and `λ`
  2. `*`, `+*`, and `-*`
- 3. `?`, `+?`, and `-?` ([deprecated syntax](https://github.com/typelevel/kind-projector/issues/108); same meaning as the above)
  4. `Λ$`
  5. `α$`, `β$`, ...
 

--- a/src/test/scala-2.13.2+/WarningSuppression.scala
+++ b/src/test/scala-2.13.2+/WarningSuppression.scala
@@ -1,7 +1,0 @@
-//don't actually run anything, just demonstrate this compiles with fatal warnings
-object Example {
-  def bar[T[_]] = ()
-
-  @scala.annotation.nowarn("cat=deprecation")
-  def f() = bar[Either[Int, ?]]
-}

--- a/src/test/scala/test.scala
+++ b/src/test/scala/test.scala
@@ -14,8 +14,8 @@ object Test {
   baz[({type L[X,Y] = Tuple3[Int, X, Y]})#L]
 
   // used to test the plugin
-  bar[Either[Int, ?]]
-  baz[Tuple3[Int, ?, ?]]
+  bar[Either[Int, *]]
+  baz[Tuple3[Int, *, *]]
   baz[Tuple3[*, Int, *]]
 
   // should not be changed by the plugin
@@ -41,8 +41,7 @@ object Test {
 
   trait Functor[F[_]]
   trait EitherT[F[_], A, B]
-  qux[Functor[?[_]]]
-  qux[EitherT[?[_], Int, Double]]
+  qux[Functor[*[_]]]
   qux[EitherT[*[_], Int, Double]]
 
   // higher higher order
@@ -54,7 +53,7 @@ object Test {
   vex[Lambda[A[B[C]] => Unit]]
 
   trait FunctorK[F[_[_]]]
-  vex[FunctorK[?[_[_]]]]
+  vex[FunctorK[*[_[_]]]]
 
   def hex[T[_[_[_[_]]]]] = ()
   hex[({type L[A[_[_[_]]]] = Unit})#L]
@@ -63,14 +62,13 @@ object Test {
   // covariant
   def mux[T[+_]] = ()
   mux[({type L[+A] = Either[A, Int]})#L]
-  mux[Either[+?, Int]]
+  mux[Either[+*, Int]]
   mux[Lambda[`+A` => Either[A, Int]]]
   mux[Lambda[+[A] => Either[A, Int]]]
 
   // contravariant
   def bux[T[-_, +_]] = ()
   bux[({type L[-A, +B] = Function2[A, Int, B]})#L]
-  bux[Function2[-?, Int, +?]]
   bux[Function2[-*, Int, +*]]
   bux[Lambda[(`-A`, `+B`) => Function2[A, Int, B]]]
   bux[Lambda[(-[A], +[B]) => Function2[A, Int, B]]]
@@ -79,9 +77,7 @@ object Test {
   trait ~>[-F[_], +G[_]]
   def tux[T[-F[_]]] = ()
   def hux[T[+G[_]]] = ()
-  tux[~>[-?[_], Option]]
   tux[~>[-*[_], Option]]
-  hux[~>[Option, +?[_]]]
   hux[~>[Option, +*[_]]]
   tux[Lambda[`-F[_]` => ~>[F, Option]]]
   hux[Lambda[`+G[_]` => ~>[Option, G]]]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.4-SNAPSHOT"
+version in ThisBuild := "0.12.0-SNAPSHOT"


### PR DESCRIPTION
Scala 2.13.6 and 2.12.14 will interpret `?` as a wildcard when using the
`-Xsource:3` flag (cf https://github.com/scala/scala/pull/9560). This
means that the old kind-projector syntax will no longer work, so it
seems like a good time to remove it. This will also allow us to compile
more of the community-build with `-Xsource:3` enabled (cf
https://github.com/scala/scala-dev/issues/769).

Sincet this is a breaking change, we also bump the version to
0.12.0-SNAPSHOT.