### PR TITLE
Update Scala to 2.13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           - 2.13.3
           - 2.13.4
           - 2.13.5
+          - 2.13.6
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ inThisBuild {
       "2.13.3",
       "2.13.4",
       "2.13.5",
+      "2.13.6",
     ),
     organization := "org.typelevel",
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),


### PR DESCRIPTION
Can v0.13.0 also be released for scala 2.13.6?