### PR TITLE
Fix a bug with `-P:kind-projector:underscore-placeholders` when an invalid type tree was generated for Java types with wildcards

### DIFF
--- a/src/test/scala/underscores/javawildcards.scala
+++ b/src/test/scala/underscores/javawildcards.scala
@@ -1,0 +1,6 @@
+package underscores
+
+object shouldWork extends sun.invoke.WrapperInstance {
+  override def getWrapperInstanceType: Class[a] forSome { type a } = ???
+  override def getWrapperInstanceTarget: java.lang.invoke.MethodHandle = ???
+}


### PR DESCRIPTION
Also avoids setting position for trees that weren't modified.

/cc @larsrh 