### PR TITLE
Make it simple to back publish

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -505,6 +505,23 @@ command-line. For instance:
 scalac -Xplugin:kind-projector_2.13.6-0.13.2.jar test.scala
 ```
 
+### Releasing the plugin
+
+This project must use full cross-versioning and thus needs to be
+republished for each new release of Scala, but if the code doesn't
+change, we prefer not to ripple downstream with a version bump.  Thus,
+we typically republish from a tag.
+
+1. Be sure you're on Java 8.
+
+2. Run `./scripts/back-publish` with the tag and Scala version
+
+   ```console
+   $ ./scripts/back-publish
+   Usage: ./scripts/back-publish [-t <tag>] [-s <scala_version>]
+   $ ./scripts/back-publish -t v0.13.2 -s 2.13.8
+   ```
+
 ### Known issues & errata
 
 When dealing with type parameters that take covariant or contravariant

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "devshell": {
+      "locked": {
+        "lastModified": 1640301433,
+        "narHash": "sha256-eplae8ZNiEmxbOgwUn9IihaJfEUxoUilkwciRPGskYE=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f87fb932740abe1c1b46f6edd8a36ade17881666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1641463613,
+        "narHash": "sha256-xZN9igqdZvnhSeTx8OlGby/OaYQHwgXVrBrPW0gLEh8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "77fda7f672726e1a95c8cd200f27bccfc86c870b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": [
+          "typelevel-nix",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "typelevel-nix",
+          "nixpkgs"
+        ],
+        "typelevel-nix": "typelevel-nix"
+      }
+    },
+    "typelevel-nix": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1641671288,
+        "narHash": "sha256-HsBfPkmGHYaxD5DSWIOGEbb+efZ2gSIk0cnb/Fcq3ls=",
+        "owner": "rossabaker",
+        "repo": "typelevel-nix",
+        "rev": "84647afdc8daee2abcbdcc520dbd3f212050f066",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossabaker",
+        "repo": "typelevel-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Provision a dev environment";
+
+  inputs = {
+    typelevel-nix.url = "github:rossabaker/typelevel-nix";
+    nixpkgs.follows = "typelevel-nix/nixpkgs";
+    flake-utils.follows = "typelevel-nix/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, typelevel-nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ typelevel-nix.overlay ];
+        };
+      in
+      {
+        devShell = pkgs.devshell.mkShell {
+          imports = [ typelevel-nix.typelevelShell ];
+          name = "kind-projector";
+          typelevelShell = {
+            jdk.package = pkgs.jdk8;
+          };
+          commands = [{
+            name = "back-publish";
+            help = "back publishes a tag to Sonatype with a specific Scala version";
+            command = "${./scripts/back-publish} $@";
+          }];
+        };
+      }
+    );
+}

--- a/scripts/back-publish
+++ b/scripts/back-publish
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() {
+    echo "Usage: $0 [-t <tag>] [-s <scala_version>]" 1>&2
+    echo "Example: $0 -t v0.13.2 -s 2.13.8"
+}
+
+while getopts "s:t:" OPTION; do
+    case $OPTION in
+	s)
+            SCALA_VERSION=$OPTARG
+            ;;
+	t)
+            TAG=$OPTARG
+            ;;
+	*)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$SCALA_VERSION" ] || [ -z "$TAG" ]; then
+    usage
+    exit 1
+fi
+
+JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+if [ "$JAVA_VERSION" -ne 8 ]; then
+    echo "Detected Java ${JAVA_VERSION}, must be 8."
+    exit 1
+fi
+
+git checkout $TAG
+sbt ++$SCALA_VERSION clean test publishSigned sonatypeRelease


### PR DESCRIPTION
This project really doesn't see significant maintenance anymore other than to republish from old tags.  I forget how to do it every time, and doing it wrong would be bad.

* `./scripts/back-publish` makes it a one-liner for anybody
* The Nix folderol (optional) gets the right JVM and adds back-publish to the path

Means we don't necessarily have to solve #196.