### PR TITLE
rossabaker/typelevel-nix -> typelevel/typelevel-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755829505,
-        "narHash": "sha256-4/Jd+LkQ2ssw8luQVkqVs9spDBVE6h/u/hC/tzngsPo=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f937f8ecd1c70efd7e9f90ba13dfb400cf559de4",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {
@@ -90,15 +90,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756139935,
-        "narHash": "sha256-TXKpykJpKQ7qHJV6Es06XKTehFaW1D0EWWP7xb583KY=",
-        "owner": "rossabaker",
+        "lastModified": 1757345616,
+        "narHash": "sha256-nF/ZlHBfA5R1WZtgLM8LUiRnCNJMzQifRtT7meousVE=",
+        "owner": "typelevel",
         "repo": "typelevel-nix",
-        "rev": "03d57b4115bd6c1f3598d0b7007cdbf0a4b3f6e7",
+        "rev": "98a62b783a7ae63e43d7bb4291423f1c58317b1d",
         "type": "github"
       },
       "original": {
-        "owner": "rossabaker",
+        "owner": "typelevel",
         "repo": "typelevel-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Provision a dev environment";
 
   inputs = {
-    typelevel-nix.url = "github:rossabaker/typelevel-nix";
+    typelevel-nix.url = "github:typelevel/typelevel-nix";
     nixpkgs.follows = "typelevel-nix/nixpkgs";
     flake-utils.follows = "typelevel-nix/flake-utils";
   };


### PR DESCRIPTION
That repo moved a long time ago.  I think the only reason it has been working is a redirect on GitHub's side.